### PR TITLE
Fix appveyor to run windows builds correctly.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  #- JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  #- JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
-#matrix:
-#  allow_failures:
+matrix:
+  allow_failures:
 #  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,8 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"SDL\"); Pkg.build(\"SDL\")"
+      Pkg.clone(pwd(), \"SDL2\"); Pkg.build(\"SDL2\");
+      Pkg.build(\"Cairo\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"SDL\")"
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"SDL2\")"


### PR DESCRIPTION
After this PR, appveyor should report that the windows build works correctly.
See https://ci.appveyor.com/project/NHDaly/sdl2-jl/build/1.0.26 for this PR's
successful build.

Note that I had to disable 32 bit julia builds because Cairo seems to fail, and
I changed the julia nightly build into running but not affecting the test
success because WinRPM doesn't seem to work on v0.7.

---

Enabling Appveyor wasn't too hard, I did it through the github marketplace:
https://github.com/marketplace/appveyor.

(However, before I could enable it, I had to delete my old private repos I still
had from back when I had a student account and github allowed for 5 free
private repos. 😊)