### PR TITLE
Fix Clang-generated enum type: BlendMode UInt32

### DIFF
--- a/src/lib/SDL_h.jl
+++ b/src/lib/SDL_h.jl
@@ -554,7 +554,7 @@ const UNSUPPORTED = (UInt32)(4)
 const LASTERROR = (UInt32)(5)
 # end enum ANONYMOUS_4
 
-const errorcode = Void
+const errorcode = UInt32
 
 mutable struct Mutex
 end
@@ -822,7 +822,7 @@ const WINDOW_TOOLTIP = (UInt32)(262144)
 const WINDOW_POPUP_MENU = (UInt32)(524288)
 # end enum ANONYMOUS_14
 
-const WindowFlags = Void
+const WindowFlags = UInt32
 
 # begin enum ANONYMOUS_15
 const ANONYMOUS_15 = UInt32

--- a/src/lib/SDL_h.jl
+++ b/src/lib/SDL_h.jl
@@ -775,7 +775,7 @@ const BLENDMODE_ADD = (UInt32)(2)
 const BLENDMODE_MOD = (UInt32)(4)
 # end enum ANONYMOUS_13
 
-const BlendMode = Void
+const BlendMode = UInt32
 
 mutable struct Surface
     flags::Uint32


### PR DESCRIPTION
Clang turned the type-name of the enum into `Void`, but it should be the enum's
base-type instead.

This prevents calling any method that takes the enum as its input,
in my case it's `SDL2.SetRenderDrawBlendMode(renderer, UInt32(SDL2.BLENDMODE_BLEND))`
([here](https://github.com/jonathanBieler/SDL2.jl/blob/88c360a40e34341917c83c6280f92444167d6d11/src/lib/SDL.jl#L3756)).