### PR TITLE
Restrict SDL_ttf and SDL_mixer to mac-only.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,8 +4,9 @@ using Compat
 @BinDeps.setup
 
 libSDL2 = library_dependency("libSDL2", aliases = ["sdl2", "libsdl2-2.0", "libSDL","SDL2"])
-libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"])
-libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"])
+# For now, these libraries don't work on Windows for some reason..
+libSDL2_ttf = library_dependency("libSDL2_ttf", aliases = ["SDL_ttf","SDL2_ttf"], os = :Darwin)
+libSDL2_mixer = library_dependency("libSDL2_mixer", aliases = ["SDL_mixer","SDL2_mixer"], os = :Darwin)
 
 if is_apple()
     using Homebrew
@@ -17,7 +18,8 @@ end
 
 if is_windows()
     provides(Binaries, URI("https://www.libsdl.org/release/SDL2-2.0.7-win32-x64.zip"), libSDL2, unpacked_dir=".")
-    provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".")
+    #provides(Binaries, URI("https://www.libsdl.org/projects/SDL_ttf/release/SDL2_ttf-2.0.14-win32-x64.zip"), libSDL2_ttf, unpacked_dir=".")
+    #provides(Binaries, URI("https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2-win32-x64.zip"), libSDL2_mixer, unpacked_dir=".")
 end
 
 provides(AptGet, "libsdl2-2.0", libSDL2)

--- a/src/SDL2.jl
+++ b/src/SDL2.jl
@@ -11,12 +11,14 @@ module SDL2
     end
 
     include("lib/SDL.jl")
-    include("lib/SDL_ttf.jl")
-    include("lib/SDL_mixer.jl")
+    if is_apple()
+        include("lib/SDL_ttf.jl")
+        include("lib/SDL_mixer.jl")
+
+        export  TTF_Init, TTF_OpenFont, TTF_RenderText_Blended, TTF_SizeText
+    end
 
     import Base.unsafe_convert
-
-    export  TTF_Init, TTF_OpenFont, TTF_RenderText_Blended, TTF_SizeText
 
     type SDLWindow
         win::Ptr{Window}
@@ -60,8 +62,10 @@ module SDL2
         GL_SetAttribute(GL_MULTISAMPLEBUFFERS, 4)
         GL_SetAttribute(GL_MULTISAMPLESAMPLES, 4)
         Init(Int32(INIT_VIDEO))
-        TTF_Init()
-        Mix_OpenAudio(Int32(22050), Int32(MIX_DEFAULT_FORMAT), Int32(2), Int32(1024) )
+        if is_apple()
+            TTF_Init()
+            Mix_OpenAudio(Int32(22050), Int32(MIX_DEFAULT_FORMAT), Int32(2), Int32(1024) )
+        end
     end
 
     function mouse_position()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,9 +3,11 @@ using Base.Test
 
 include("lib/SDL.jl")
 
+if is_apple()
 include("lib/SDL_ttf.jl")
-
 include("lib/SDL_mixer.jl")
+end
+
 
 # Integration tests
 @testset "example1" begin


### PR DESCRIPTION
Since we can't get these libraries to work on windows, I've just disabled them
if not running on an apple platform. This fixes the appveyor build for windows,
at least. So SDL will at least be usable from windows...