### PR TITLE
delete warn(t) log in SDL2.Event(t)

### DIFF
--- a/src/lib/SDL_h.jl
+++ b/src/lib/SDL_h.jl
@@ -1858,7 +1858,6 @@ const event_type_to_event = Dict{UInt32,Any}( #FIXME AbstractEvent?
 
 function Event(t::Uint8)
     haskey(event_type_to_event,t) && return event_type_to_event[t]
-    warn(t)
     nothing
 end
 


### PR DESCRIPTION
Removes WARNING: logs when polling events. If you want, maybe we could/should
change this to be like an optional debug flag or something?