### PR TITLE
Add License to project

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Jonathan Bieler <jonathan.bieler@alumni.epfl.ch>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Jonathan Bieler <jonathan.bieler@alumni.epfl.ch>
+Copyright (c) 2018: Jonathan Bieler, Nathan Daly
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@
 Bindings for the [Simple DirectMedia Layer](https://www.libsdl.org/) library. The bindings were generated using [Clang.jl](https://github.com/ihnorton/Clang.jl). The `SDL_` prefix was trimmed from names so functions and types can be accessed as `SDL2.foo` instead of `SDL_foo`. Documentation can be found on the [SDL wiki](https://wiki.libsdl.org/FrontPage).
 
 A few examples are available [here](https://github.com/jonathanBieler/SDL2.jl/blob/master/src/examples/).
+
+# License
+This project is licensed under the terms of the MIT license.
+


### PR DESCRIPTION
Hi! We should add a license! That's another useful step before other people can use this.

I just used the MIT license, which I think is the norm for open source stuff. Here's github's license guide:
https://choosealicense.com/

If you think this looks good you can just merge it, or feel free to change it to a different license or change the text or whatever! :) This is just a good thing to have.
