### PR TITLE
Add BinDeps and Compat requirements (required for building)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.6
+BinDeps
 Cairo
 ColorTypes
-BinDeps
 Compat

--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ BinDeps
 Cairo
 ColorTypes
 Compat
+Homebrew

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,5 @@
 julia 0.6
 Cairo
 ColorTypes
+BinDeps
+Compat


### PR DESCRIPTION
I tried building on v0.7 and it complained that `BinDeps` wasn't installed.